### PR TITLE
Decouple DoctrineAdapter from DoctrineAdapterFactory

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -7,6 +7,8 @@ return [
                 'ZF\OAuth2\Doctrine\Adapter\DoctrineAdapterFactory',
             'ZF\OAuth2\Doctrine\Mapper\MapperManager' =>
                 'ZF\OAuth2\Doctrine\Mapper\MapperManager',
+            'ZF\OAuth2\Doctrine\Adapter\DoctrineAdapter' =>
+                'ZF\OAuth2\Doctrine\Adapter\DoctrineAdapter',    
         ],
         'shared' => [
             'ZF\OAuth2\Doctrine\Adapter\DoctrineAdapterFactory' => false,

--- a/src/Adapter/DoctrineAdapterFactory.php
+++ b/src/Adapter/DoctrineAdapterFactory.php
@@ -29,7 +29,7 @@ class DoctrineAdapterFactory implements FactoryInterface
      */
     public function createService(ServiceLocatorInterface $services)
     {
-        $adapter = new DoctrineAdapter();
+        $adapter = $services->get('ZF\OAuth2\Doctrine\Adapter\DoctrineAdapter');
 
         $adapter->setConfig($this->config);
         $adapter->setObjectManager($this->loadObjectManager($services, $this->config->object_manager));


### PR DESCRIPTION
Hey Tom,

Would it be an option to use the ServiceManager to get a DoctrineAdapter instance? In my use case, I want to override the checkUserCredentials() method of the DoctrineAdapter, so that it also checks if a user has verified their email address and I have not disabled their account (for example when they are behind on their payments). 

If they do not pass this check but still get an access token, they will have the idea that they can log in, but any subsequent requests using the token they just got will be blocked (I check the user status on every request).

Let me know!